### PR TITLE
Update spark-sql dependency version to fix expand macro errors.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-sql_2.10</artifactId>
+        <artifactId>spark-sql_2.11</artifactId>
         <version>${spark.version}</version>
 	<scope>test</scope>
       </dependency>

--- a/utils-intervalrdd/pom.xml
+++ b/utils-intervalrdd/pom.xml
@@ -102,6 +102,10 @@
       <artifactId>spark-core_2.11</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.11</artifactId>
       <scope>test</scope>

--- a/utils-metrics/pom.xml
+++ b/utils-metrics/pom.xml
@@ -115,6 +115,10 @@
       <artifactId>spark-core_2.11</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.11</artifactId>
       <scope>test</scope>

--- a/utils-misc/pom.xml
+++ b/utils-misc/pom.xml
@@ -102,7 +102,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.10</artifactId>
+      <artifactId>spark-sql_2.11</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Not sure how this branch got pushed to bigdatagenomics/utils instead of my fork, but I don't suppose that does any harm.